### PR TITLE
updated gitignore structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,1 @@
-node_modules
-.env
-groovy-height-404319-b1648a1b13c5.json
-.DS_STORE
-google-services.json
 /inclusivechatapp/

--- a/mobile-app/.gitignore
+++ b/mobile-app/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+google-services.json

--- a/web-app/.gitignore
+++ b/web-app/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.env
+groovy-height-404319-b1648a1b13c5.json
+.DS_STORE
+google-services.json


### PR DESCRIPTION
- .gitignore in the root folder of repo is common to the entire project
- .gitignore in the mobile and web folders are specific to the android and web projects